### PR TITLE
Keep directories for generated files in repository

### DIFF
--- a/net.sf.crsx.xtext.Crsx.tests/src-gen/.gitignore
+++ b/net.sf.crsx.xtext.Crsx.tests/src-gen/.gitignore
@@ -1,0 +1,3 @@
+#Ignore everything in this directory except this file
+*
+!.gitignore

--- a/net.sf.crsx.xtext.Crsx.ui/.gitignore
+++ b/net.sf.crsx.xtext.Crsx.ui/.gitignore
@@ -1,2 +1,2 @@
 /bin/
-/src-gen/
+

--- a/net.sf.crsx.xtext.Crsx.ui/src-gen/.gitignore
+++ b/net.sf.crsx.xtext.Crsx.ui/src-gen/.gitignore
@@ -1,0 +1,3 @@
+#Ignore everything in this directory except this file
+*
+!.gitignore

--- a/net.sf.crsx.xtext.Crsx/.gitignore
+++ b/net.sf.crsx.xtext.Crsx/.gitignore
@@ -1,3 +1,2 @@
 /bin/
-/src-gen/
-/xtend-gen/
+

--- a/net.sf.crsx.xtext.Crsx/src-gen/.gitignore
+++ b/net.sf.crsx.xtext.Crsx/src-gen/.gitignore
@@ -1,0 +1,3 @@
+#Ignore everything in this directory except this file
+*
+!.gitignore

--- a/net.sf.crsx.xtext.Crsx/xtend-gen/.gitignore
+++ b/net.sf.crsx.xtext.Crsx/xtend-gen/.gitignore
@@ -1,0 +1,3 @@
+#Ignore everything in this directory except this file
+*
+!.gitignore


### PR DESCRIPTION
Eclipse complains about missing directories after importing the project, some of them were not created automatically after running the first build. After creating directories manually build was successful. 
I suggest to keep directories for generated files in the repository and ignore only contents of these directories.
